### PR TITLE
correcting dependencies after running `pytest`

### DIFF
--- a/picrust2-env.yaml
+++ b/picrust2-env.yaml
@@ -4,10 +4,12 @@ channels:
 - conda-forge
 - r
 - bioconda
+- anaconda
 - defaults
 
 dependencies:
 - biom-format >=2.1.10
+- cython
 - epa-ng=0.3.8
 - gappa=0.7.0
 - glpk=4.65


### PR DESCRIPTION
After running `pytest` during install `biom-format` required `cython` installation to run properly. Added `cython` to `picrust2-env.yml`