### PR TITLE
Fix picrust2-env.yaml dependencies

### DIFF
--- a/picrust2-env.yaml
+++ b/picrust2-env.yaml
@@ -2,12 +2,15 @@ name: picrust2
 
 channels:
 - conda-forge
+- etetoolkit
 - r
 - bioconda
 - anaconda
 - defaults
 
 dependencies:
+- python >=3.10
+- r-base >=3.5.1
 - biom-format >=2.1.10
 - cython
 - epa-ng =0.3.8
@@ -23,8 +26,7 @@ dependencies:
 - pandas >=1.1.5
 - pytest >=4.4.1
 - pytest-cov >=2.6.1
-- python >=3.5
-- r-base >=3.5.1
+- typeguard =4.4.2
 - r-castor >=1.7.2
 - scipy >=1.2.1
 - sepp =4.5.5


### PR DESCRIPTION
Current dependencies specified in picrust2-env.yaml does not install using mamba/conda env create -f picrust2-env.yaml. These changes need to be made for successful installment.

1. ete3 has to be installed from etetoolkit channel. conda-forge does not work, even though it is listed on https://anaconda.org/conda-forge/ete3.
2. Installing sepp 4.5.5 requires python3.10.
3. Runnning test requires typeguard 4.4.2 to be specified separately.

The updated package has been tested with pytest under source directory.

I sincerely appreciate the efforts of the developers to maintain this wonderful package and expand its functionality continously. It's such a blessing for the microbial bioinformatics community to have it🤗